### PR TITLE
Missing attribute on order constraint 2

### DIFF
--- a/tasks/cluster-resources.yml
+++ b/tasks/cluster-resources.yml
@@ -152,7 +152,7 @@
 - name: Create Cluster order constraint 2
   shell: |
     pcs constraint order start {{ _ascs_group }}  \
-    then stop {{ _ers_group }} symmetrical=false
+    then stop {{ _ers_group }} kind=optional symmetrical=false
   register: create_constraint1
   changed_when: "'Adding SAPHanaTopology' in create_constraint1.stdout"
   run_once: true  


### PR DESCRIPTION
By default the cluster applies `kind=mandatory` when the value isn't specified.

As with the first constraint, the second constraint also needs a kind=optional flag added.

Source:
https://access.redhat.com/articles/3974941#create-constraints